### PR TITLE
Fix match css

### DIFF
--- a/html5validator/cli.py
+++ b/html5validator/cli.py
@@ -83,7 +83,7 @@ vnu.jar help below.
                                         if isinstance(s, bytes) else s),
                         dest='ignore_re',
                         help='regular expression of messages to ignore')
-    parser.add_argument("--config", help="Path to a config file for options")
+    parser.add_argument("--config", help="Path to a config file for options. Takes precedence over command line options")
     parser.add_argument('-l', action='store_const', const=2048,
                         dest='stack_size',
                         help=('run on larger files: sets Java '
@@ -142,6 +142,9 @@ vnu.jar help below.
             args.match = ['*.css']
         if '--skip-non-svg' in extra_args:
             args.match = ['*.svg']
+
+    if any(m.endswith('.css') for m in args.match) and ('--also-check-css' not in extra_args and '--css' not in extra_args):
+        extra_args.append('--css')
 
     if args.log_file is None:
         logging.basicConfig(level=getattr(logging, args.log))

--- a/html5validator/validator.py
+++ b/html5validator/validator.py
@@ -37,8 +37,8 @@ class JavaNotFoundException(Exception):
 
 
 def all_files(
-        directory: str = '.',
-        match: str = '*.html',
+        directory: str,
+        match: list[str],
         blacklist: Optional[List[str]] = None,
         skip_invisible: bool = True) -> List:
     if blacklist is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ build = [
 dev = [
     "hacking>=6.0.1",
     "pytest>=8.3.5",
+    "setuptools>=75.3.2",
+    "wheel>=0.45.1",
 ]
 
 # Configure setuptools for flat-layout package discovery and data inclusion

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,7 @@ def test_config_skip():
     """Config test for skipping files"""
     assert subprocess.call([
         'html5validator',
-        f'--config={HTML_TEST_FILES}/config_files/skip.yaml']) == 2
+        f'--config={HTML_TEST_FILES}/config_files/skip.yaml']) == 1
 
 
 def test_config_invalid_with_css():
@@ -39,7 +39,7 @@ def test_config_invalid_css_only():
     """Config test for CSSS only"""
     assert subprocess.call([
         'html5validator',
-        f"--config={HTML_TEST_FILES}/config_files/invalid_css_only.yaml"]) == 2
+        f"--config={HTML_TEST_FILES}/config_files/invalid_css_only.yaml"]) == 1
 
 
 def test_config_invalid_single_file():

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -34,6 +34,7 @@ def test_invalid_css_only():
         'html5validator',
         '--root', f'{HTML_TEST_FILES}/invalid/',
         '--skip-non-css',
+        '--log', 'DEBUG'
     ]) == 1
 
 
@@ -192,6 +193,22 @@ def test_nofiles():
         "html5validator", "--root=MISSING"
     ]) == 1
 
+def test_match():
+    """Command line test for matching file pattern"""
+
+    # assert subprocess.call(['html5validator',
+    #                         f'--root={HTML_TEST_FILES}/invalid/',
+    #                         '--match', '*.html',
+    #                         ]) == 1
+    assert subprocess.call(['html5validator',
+                            f'--root={HTML_TEST_FILES}/invalid/',
+                            '--match', '*.css',
+                            '--log', 'DEBUG'
+                            ]) == 1
+    assert subprocess.call(['html5validator',
+                            f'--root={HTML_TEST_FILES}/invalid/',
+                            '--match', '*.html', '*.css',
+                            ]) == 3
 
 if __name__ == '__main__':
     test_valid()
@@ -207,3 +224,4 @@ if __name__ == '__main__':
     test_log_file()
     test_skip()
     test_nofiles()
+    test_match()

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -196,10 +196,10 @@ def test_nofiles():
 def test_match():
     """Command line test for matching file pattern"""
 
-    # assert subprocess.call(['html5validator',
-    #                         f'--root={HTML_TEST_FILES}/invalid/',
-    #                         '--match', '*.html',
-    #                         ]) == 1
+    assert subprocess.call(['html5validator',
+                            f'--root={HTML_TEST_FILES}/invalid/',
+                            '--match', '*.html',
+                            ]) == 1
     assert subprocess.call(['html5validator',
                             f'--root={HTML_TEST_FILES}/invalid/',
                             '--match', '*.css',

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -112,7 +112,10 @@ dev = [
     { name = "hacking", version = "6.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
     { name = "hacking", version = "7.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1'" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "wheel" },
 ]
 
 [package.metadata]
@@ -126,6 +129,8 @@ build = [
 dev = [
     { name = "hacking", specifier = ">=6.0.1" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "setuptools", specifier = ">=75.3.2" },
+    { name = "wheel", specifier = ">=0.45.1" },
 ]
 
 [[package]]
@@ -262,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -276,9 +281,9 @@ dependencies = [
     { name = "pygments", marker = "python_full_version >= '3.9'" },
     { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -420,14 +425,14 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.9'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes an issue where using `--match` to just validate CSS would result in it being checked as HTML.